### PR TITLE
Use system commands from path instead of absolute name

### DIFF
--- a/runtime/trunks.go
+++ b/runtime/trunks.go
@@ -14,39 +14,42 @@ import (
 var Trunks *TrunksConfig
 
 func runIPtables(args ...string) error {
-	cmd := exec.Command("/sbin/iptables", args...)
+	cmd := exec.Command("iptables", args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	err := cmd.Run()
 	if nil != err {
-		log.Println("Error running /sbin/iptables:", err)
+		errLog := fmt.Sprintf("Error running %s: %s", cmd.Args[0], err)
+		log.Println(errLog)
 		return err
 	}
 	return nil
 }
 
 func runTC(args ...string) error {
-	cmd := exec.Command("/sbin/tc", args...)
+	cmd := exec.Command("tc", args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	err := cmd.Run()
 	if nil != err {
-		log.Println("Error running /sbin/tc:", err)
+		errLog := fmt.Sprintf("Error running %s: %s", cmd.Args[0], err)
+		log.Println(errLog)
 		return err
 	}
 	return nil
 }
 
 func runSYSCTL(args ...string) error {
-	cmd := exec.Command("/sbin/sysctl", args...)
+	cmd := exec.Command("sysctl", args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	err := cmd.Run()
 	if nil != err {
-		log.Println("Error running /sbin/sysctl:", err)
+		errLog := fmt.Sprintf("Error running %s: %s", cmd.Args[0], err)
+		log.Println(errLog)
 		return err
 	}
 	return nil


### PR DESCRIPTION
In debian bullseye (11), with the usrmerge, `iptables` is no longer at `/sbin/iptables` (`/usr/sbin/iptables` instead).

As stated in [go exec.Command documentation](https://pkg.go.dev/os/exec#Command), `If name contains no path separators, Command uses LookPath to resolve name to a complete path if possible. Otherwise it uses name directly as Path.`

- [x] Tested with `debian:bullseye-20211011-slim` docker image, compiled with `golang:1.17.3-bullseye`

PS: Could you tag a new release when merged?