### PR TITLE
grant privilege to the trunk service

### DIFF
--- a/container/docker-compose.yaml
+++ b/container/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     command: --config trunks.yaml --acm --qos
     volumes:
       - ./trunks.yaml:/trunks/trunks.yaml
+    privileged: true
     cap_add:
       - NET_ADMIN
     networks:


### PR DESCRIPTION
There is a sysctl setting in the Run() of trunks.go, with an intent to make the satellite a router by enable the forwarding of Linux kernel.

![image](https://github.com/user-attachments/assets/9d8e2241-47de-4d80-9a3d-3adcff21b937)


If the trunk service lacks the privileged option, it would fail to carry out the sysctl setting of "net.ipv4.ip_forward" as the permission was denied.

![1](https://github.com/user-attachments/assets/72bd907f-b97f-430f-bc70-1e09edeb88d8)

So it's recommended to grant privilege to the trunk service for the purpose of making sure the runtime would be able to configure "net.ipv4.ip_forward = 1"

![2](https://github.com/user-attachments/assets/8302f686-a58f-4004-b0ab-b4e38d65b8d5)
